### PR TITLE
Fix typo in BridgeFederation top object class ID

### DIFF
--- a/schema/99-user.ldif
+++ b/schema/99-user.ldif
@@ -14,7 +14,7 @@ attributeTypes: ( 1.3.6.1.4.1.42750.2.2 NAME 'BridgeFederationUID' EQUALITY case
 attributeTypes: ( 1.3.6.1.4.1.42750.2.5 NAME 'BridgeFederationUmbrellaUsername' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 USAGE userApplications )
 attributeTypes: ( 1.3.6.1.4.1.5923.1.1.1.16 NAME 'eduPersonOrcid' EQUALITY caseIgnoreMatch ORDERING caseIgnoreOrderingMatch SUBSTR caseIgnoreSubstringsMatch SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 USAGE userApplications )
 objectClasses: ( 1.3.6.1.4.1.42750.1.1 NAME 'EAAUser' SUP top STRUCTURAL MUST ( objectClass $ uid $ userPassword $ EAABirthdate $ ou $ mail $ EAAHash $ EAAKey ) MAY ( EAAResetPwDate $ EAAResetPWUUID $ givenName $ homePhone $ homePostalAddress $ mobile $ sn $ postalAddress $ telephoneNumber $ emailAddress $ eduPersonOrcid) )
-objectClasses: ( 1.3.6.1.4.142750.2.4 NAME 'BridgeFederation' SUP top STRUCTURAL MUST ( objectClass $ uid $ BridgeFederationSrc $ BridgeFederationUID $ BridgeFederationUmbrellaUID $ ou $ BridgeFederationUmbrellaUsername ) )
+objectClasses: ( 1.3.6.1.4.1.42750.2.4 NAME 'BridgeFederation' SUP top STRUCTURAL MUST ( objectClass $ uid $ BridgeFederationSrc $ BridgeFederationUID $ BridgeFederationUmbrellaUID $ ou $ BridgeFederationUmbrellaUsername ) )
 ds-sync-generation-id: 8408
 modifiersName: cn=Internal Client,cn=Root DNs,cn=config
 modifyTimestamp: 20130604160251Z


### PR DESCRIPTION
It seems there is a typo in the object class id for `BridgeFederation `.
Current value is `1.3.6.1.4.142750.2.4` while it should be `1.3.6.1.4.1.42750.2.4`.